### PR TITLE
Add Zodiac quests with unsync dungeons

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Relics/357_A Ponze of Flesh.json
+++ b/QuestPaths/2.x - A Realm Reborn/Relics/357_A Ponze of Flesh.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://github.com/WigglyMuffin/Questionable/raw/refs/heads/main/QuestPaths/quest-v1.json",
+  "Author": "liza",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1010809,
+          "Position": {
+            "X": 73.10596,
+            "Y": 33.06655,
+            "Z": -704.4022
+          },
+          "TerritoryId": 156,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1010809,
+          "Position": {
+            "X": 73.10596,
+            "Y": 33.06655,
+            "Z": -704.4022
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 13
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            128
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 20
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            64
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1010809,
+          "Position": {
+            "X": 73.10596,
+            "Y": 33.06655,
+            "Z": -704.4022
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 21
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            128
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 27
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            64
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1010809,
+          "Position": {
+            "X": 73.10596,
+            "Y": 33.06655,
+            "Z": -704.4022
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1010809,
+          "Position": {
+            "X": 73.10596,
+            "Y": 33.06655,
+            "Z": -704.4022
+          },
+          "TerritoryId": 156,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Relics/358_Labor of Love.json
+++ b/QuestPaths/2.x - A Realm Reborn/Relics/358_Labor of Love.json
@@ -1,0 +1,272 @@
+{
+  "$schema": "https://github.com/WigglyMuffin/Questionable/raw/refs/heads/main/QuestPaths/quest-v1.json",
+  "Author": "liza",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 5
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            128
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 19
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            64
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 22
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            128
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 28
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            64
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.830208,
+            "Y": 28.999964,
+            "Z": -730.27045
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "DataId": 1006971,
+          "Position": {
+            "X": 24.307495,
+            "Y": 29.021706,
+            "Z": -726.8635
+          },
+          "StopDistance": 5,
+          "TerritoryId": 156,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Relics/359_Method in His Malice.json
+++ b/QuestPaths/2.x - A Realm Reborn/Relics/359_Method in His Malice.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://github.com/WigglyMuffin/Questionable/raw/refs/heads/main/QuestPaths/quest-v1.json",
+  "Author": "liza",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 141,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 10
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "TerritoryId": 141,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 18
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "TerritoryId": 141,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 23
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 7,
+      "Steps": [
+        {
+          "TerritoryId": 141,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 26
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 8,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 9,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1010810,
+          "Position": {
+            "X": 109.4834,
+            "Y": 31,
+            "Z": -388.8457
+          },
+          "TerritoryId": 141,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Relics/360_A Treasured Mother.json
+++ b/QuestPaths/2.x - A Realm Reborn/Relics/360_A Treasured Mother.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://github.com/WigglyMuffin/Questionable/raw/refs/heads/main/QuestPaths/quest-v1.json",
+  "Author": "liza",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1006981,
+          "Position": {
+            "X": 25.711426,
+            "Y": 28.999966,
+            "Z": -738.21625
+          },
+          "TerritoryId": 156,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1006981,
+          "Position": {
+            "X": 25.711426,
+            "Y": 28.999966,
+            "Z": -738.21625
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1010811,
+          "Position": {
+            "X": 645.2583,
+            "Y": 5.6312623,
+            "Z": 551.59827
+          },
+          "TerritoryId": 138,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Western La Noscea - Swiftperch",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 14
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            128
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 17
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            64
+          ]
+        },
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 24
+          },
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            32
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1010811,
+          "Position": {
+            "X": 645.2583,
+            "Y": 5.6312623,
+            "Z": 551.59827
+          },
+          "TerritoryId": 138,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Western La Noscea - Swiftperch",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "TerritoryId": 156,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": true,
+            "ContentFinderConditionId": 25
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 1010811,
+          "Position": {
+            "X": 645.2583,
+            "Y": 5.6312623,
+            "Z": 551.59827
+          },
+          "TerritoryId": 138,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Western La Noscea - Swiftperch",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1006981,
+          "Position": {
+            "X": 25.711426,
+            "Y": 28.999966,
+            "Z": -738.21625
+          },
+          "TerritoryId": 156,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mor Dhona",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the quests for the i125 step of the ARR relic, see https://ffxiv.consolegameswiki.com/wiki/Zodiac_Braves_Weapons/Quest for details.

All dungeons for it will be run unsync (this isn't really configurable, most people don't give two cents about running these dungeons sync), and they mostly* work:
- I think the first boss in `Lost City of Amdapor` would need a module if you want to make it less RNG, right now you're just waiting for an add to spawn close enough so that you get hit.
- Stone Vigil (Hard) probably needs some code in AD for using the cannons (not during any boss, just in one of the corridors), but its not a big deal if you're manually watching over it

